### PR TITLE
Fix for https://github.com/microprofile/microprofile-tutorial/issues/30

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -163,7 +163,7 @@ content:
 ----
 ui:
   bundle:
-    url: https://github.com/ttelang/microprofile-documentation-ui/releases/download/latest/ui-bundle.zip
+    url: https://github.com/microprofile/microprofile-tutorial-ui/releases/download/latest/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui
 ----
@@ -177,7 +177,7 @@ The `antora.yml` file defines the documentation component:
 name: microprofile-tutorial
 title: MicroProfile Tutorial
 version: 6.1
-edit_url: https://github.com/ttelang/microprofile-tutorial/edit/patch-15/modules/ROOT/pages/{path}
+edit_url: https://github.com/microprofile/microprofile-tutorial/tree/main/modules/ROOT/pages/{path}
 asciidoc:
   attributes:
     source-language: asciidoc@
@@ -291,7 +291,7 @@ The `fix-edit-links.sh` script is a necessary post-processing step in the build 
 
 The script performs a simple text replacement in the generated HTML files, replacing local file paths with proper GitHub repository URLs. This ensures that the "Edit this Page" links work correctly for users viewing the documentation.
 
-If you update the repository URL or branch name, make sure to update the replacement URL in the `fix-edit-links.sh` script accordingly. The current implementation assumes the GitHub repository URL is `https://github.com/ttelang/microprofile-tutorial` and the branch is `patch-15`.
+If you update the repository URL or branch name, make sure to update the replacement URL in the `fix-edit-links.sh` script accordingly. The current implementation assumes the GitHub repository URL is `https://github.com/microprofile/microprofile-tutorial` and the branch is `main`.
 
 ## Automating Repository URL Configuration
 
@@ -569,7 +569,7 @@ The MicroProfile Tutorial uses a customized UI bundle from the `microprofile-doc
 ----
 ui:
   bundle:
-    url: https://github.com/ttelang/microprofile-documentation-ui/releases/download/latest/ui-bundle.zip
+    url: https://github.com/microprofile/microprofile-tutorial-ui/releases/tag/latest/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui
 ----
@@ -620,7 +620,7 @@ To update to a newer version of the UI bundle:
 ----
 ui:
   bundle:
-    url: https://github.com/ttelang/microprofile-documentation-ui/releases/download/latest/ui-bundle.zip
+    url: https://github.com/microprofile/microprofile-tutorial-ui/releases/tag/latest/ui-bundle.zip
     snapshot: true
 ----
 
@@ -628,7 +628,7 @@ ui:
 
 If you need extensive customization beyond what supplemental files allow:
 
-1. Fork the https://github.com/ttelang/microprofile-documentation-ui repository
+1. Fork the https://github.com/microprofile/microprofile-tutorial-ui repository
 2. Make your customizations following the project's README
 3. Build the UI bundle using `gulp bundle`
 4. Host the resulting ZIP file (e.g., on GitHub Releases)
@@ -648,7 +648,7 @@ You can control how Antora handles UI bundle caching:
 ----
 ui:
   bundle:
-    url: https://github.com/ttelang/microprofile-documentation-ui/releases/download/latest/ui-bundle.zip
+    url: https://github.com/microprofile/microprofile-tutorial-ui/releases/download/latest/ui-bundle.zip
     snapshot: true  # Always fetch the latest version
     # snapshot: false  # Use cached version when available
 ----
@@ -665,7 +665,7 @@ Modern UI bundles for Antora can include advanced features:
 ----
 ui:
   bundle:
-    url: https://example.com/ui-bundle.zip
+    url: https://github.com/microprofile/microprofile-tutorial-ui/releases/download/latest/ui-bundle.zip
   supplemental_files: ./supplemental-ui
 search:
   engine: lunr  # Or another search engine
@@ -678,7 +678,7 @@ search:
 ----
 ui:
   bundle:
-    url: https://example.com/ui-bundle.zip
+    url: https://github.com/microprofile/microprofile-tutorial-ui/releases/download/latest/ui-bundle.zip
 output:
   dir: ./build/site
   formats:
@@ -709,7 +709,7 @@ ui:
     url: ./path/to/local/ui-bundle.zip
     snapshot: true
 ----
-
+Replease _./path/to/local/ui-bundle.zip_ with actual path to your local UI bundle under development.
 This approach is useful when developing your own UI bundle or testing modifications.
 
 ### UI Bundle Development

--- a/antora.yml
+++ b/antora.yml
@@ -1,7 +1,7 @@
 name: microprofile-tutorial
 title: MicroProfile Tutorial
 version: 6.1
-edit_url: https://github.com/ttelang/microprofile-tutorial/edit/patch-15/modules/ROOT/pages/{path}
+edit_url: https://github.com/microprofile/microprofile-tutorial/tree/main/modules/ROOT/pages/{path}
 asciidoc:
   attributes:
     source-language: asciidoc@

--- a/build/site/microprofile-tutorial/6.1/README.html
+++ b/build/site/microprofile-tutorial/6.1/README.html
@@ -138,7 +138,7 @@
     <li><a href="README.html">README</a></li>
   </ul>
 </nav>
-  <div class="edit-this-page"><a href="https://github.com/ttelang/microprofile-tutorial/edit/patch-15/modules/ROOT/pages/README.adoc">Edit this Page</a></div>
+  <div class="edit-this-page"><a href="https://github.com/microprofile/microprofile-tutorial/edit/main/modules/ROOT/pages/README.adoc">Edit this Page</a></div>
 </div>
   <div class="content">
 <aside class="toc sidebar" data-title="Contents" data-levels="2">

--- a/fix-edit-links.sh
+++ b/fix-edit-links.sh
@@ -13,7 +13,7 @@ NC='\033[0m' # No Color
 SITE_DIR="/workspaces/microprofile-tutorial/build/site"
 
 # GitHub repository information
-REPO_URL="https://github.com/ttelang/microprofile-tutorial"
+REPO_URL="https://github.com/microprofile/microprofile-tutorial"
 BRANCH="patch-15"
 PATH_PREFIX="modules/ROOT/pages/"
 

--- a/index.adoc
+++ b/index.adoc
@@ -76,7 +76,7 @@ image::images/figureFM-1.png[MicroProfile e-Commerce Application]
 As you can see in the above figure, together these microservices form a robust and flexible e-Commerce application architecture, enabling scalable, efficient, and secure online shopping experiences.
 
 === Downloading the Code
-The code examples in this tutorial are available at this link:https://www.github.com/ttelang/microprofile-examples[repo] (TODO: to be changed).
+The code examples in this tutorial are available at this link:https://github.com/microprofile/microprofile-tutorial/tree/main/code[folder].
 
 === Prerequisites
 MicroProfile use the Java Platform, and are usually written in the Java programming language. 

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,7 +4,7 @@ site:
   start_page: "index.adoc"
 content:
   sources:
-    - url: "https://github.com/ttelang/microprofile-tutorial.git"
+    - url: "https://github.com/microprofile/microprofile-tutorial.git"
       branches: main
       start_path: /
 ui:

--- a/update-repo-url.sh
+++ b/update-repo-url.sh
@@ -15,8 +15,8 @@ echo -e "${BLUE}Detecting Git repository information...${NC}"
 REPO_URL=$(git remote get-url origin 2>/dev/null)
 if [ -z "$REPO_URL" ]; then
     echo -e "${YELLOW}Warning: Could not determine remote repository URL.${NC}"
-    echo -e "${YELLOW}Using default URL: https://github.com/ttelang/microprofile-tutorial${NC}"
-    REPO_URL="https://github.com/ttelang/microprofile-tutorial"
+    echo -e "${YELLOW}Using default URL: https://github.com/microprofile/microprofile-tutorial${NC}"
+    REPO_URL="https://github.com/microprofile/microprofile-tutorial"
 else
     # Convert SSH URL to HTTPS URL if needed
     if [[ $REPO_URL == git@github.com:* ]]; then


### PR DESCRIPTION
…profile-tutorial/issues/30

Fix for https://github.com/microprofile/microprofile-tutorial/issues/30, replacing my development repo with microprofile repo.

The references of development branch in _.html_ files would get automatically fixed after execution of Github actions workflow with this PR merge.